### PR TITLE
Add GitHub link to pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -28,6 +28,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set GitHub URL
+        run: |
+          if grep -q '^github_url:' _config.yml; then
+            sed -i "s#^github_url:.*#github_url: https://github.com/${{ github.repository }}/blob/main#" _config.yml
+          else
+            echo "github_url: https://github.com/${{ github.repository }}/blob/main" >> _config.yml
+          fi
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Build with Jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+# Jekyll configuration
+
+github_url: ""

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -237,6 +237,8 @@
         &copy; {{ site.time | date: '%Y' }}. All rights reserved.
         <br>
         <a href="https://github.com/YouXam" target="_blank">Youxam</a>
+        <br>
+        <a href="{{ site.github_url }}/{{ page.path | uri_escape }}" target="_blank">在 GitHub 中查看本页</a>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/5.0.0/anchor.min.js"
         integrity="sha512-byAcNWVEzFfu+tZItctr+WIMUJvpzT2kokkqcBq+VsrM3OrC5Aj9E2gh+hHpU0XNA3wDmX4sDbV5/nkhvTrj4w=="


### PR DESCRIPTION
## Summary
- add `_config.yml` to hold repository URL
- inject GitHub repository URL during Actions build
- link each page to view its source on GitHub
- update workflow to overwrite existing URL key

## Testing
- `jekyll build -d _site_test -c _config.base.yml test.md`
- `grep -n "在 GitHub 中查看本页" _site_test/test.html`


------
https://chatgpt.com/codex/tasks/task_e_6852f2e753888320a225a6155584499d